### PR TITLE
Added dependabot automated dependency management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/build-on-pull-request.yml
+++ b/.github/workflows/build-on-pull-request.yml
@@ -1,0 +1,21 @@
+name: Build CI
+
+on:
+  push:
+    branches:
+      - 'dependabot/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew build


### PR DESCRIPTION
* Added Dependabot support for automated dependency version management
* Added a Github build action

This will make PRs for new dependency updates, it will not auto merge them. It should make it easier for us to stay on top of dependency updates.
The Github action *should* catch breaking changes in dependency updates. It does a basic Gradle build.
Current config is set to check `daily` for updates, I would recommend this setting until Dependabot has processed all dependencies. After that we can change it to `weekly`.
Github build action will only run on PRs (branches) created by dependabot, but we could extend it to run on all PRs.

For questions about Dependabot or Github actions let me know 😉