### PR TITLE
Kotlin version is needed in order to fix our build issues with Depend…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,6 @@
 buildscript {
+    ext.kotlin_version = "1.4.30"
+
     repositories {
         google()
         maven { url 'https://plugins.gradle.org/m2/'}


### PR DESCRIPTION
Kotlin version is needed in order to fix our build issues with Dependabot and Jitpack