### PR TITLE
Updated dependabot config + removed set JDK step in workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,12 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    reviewers:
+      - "appwise-labs/circle-android"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "appwise-labs/circle-android"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,10 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"

--- a/.github/workflows/build-on-pull-request.yml
+++ b/.github/workflows/build-on-pull-request.yml
@@ -11,10 +11,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/.github/workflows/build-on-pull-request.yml
+++ b/.github/workflows/build-on-pull-request.yml
@@ -1,9 +1,7 @@
 name: Build CI
 
 on:
-  push:
-    branches:
-      - 'dependabot/**'
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
* Increased Dependabot check updates schedule to weekly 
* Increased open Dependabot PRs limit to 10 (default is 5)
* Removed set JDK step from Github workflow
  * It turns out that the Github Ubuntu CI image has Java 8 already preinstalled and the Android SDK uses it by default so no need for us to set it https://github.com/actions/virtual-environments/blob/ae60820a20b383662f9f9e630be3568724593f44/images/linux/scripts/installers/android.sh#L59-L60
* Changed workflow to trigger on every PR and not only PRs created by Dependabot
* Let Dependabot auto assign the circle-android team