### PR TITLE
Fixed build error with delete queries in BaseRoomDao

### DIFF
--- a/src/main/java/be/appwise/core/data/base/BaseRoomDao.kt
+++ b/src/main/java/be/appwise/core/data/base/BaseRoomDao.kt
@@ -76,10 +76,10 @@ abstract class BaseRoomDao<T : BaseEntity>(private val tableName: String) {
     protected abstract suspend fun deleteAllExceptIds(query: SupportSQLiteQuery) : Int
 
     @RawQuery
-    protected abstract suspend fun deleteAllFromTable(query: SupportSQLiteQuery)
+    protected abstract suspend fun deleteAllFromTable(query: SupportSQLiteQuery) : Int
 
     @RawQuery
-    protected abstract suspend fun deleteById(query: SupportSQLiteQuery)
+    protected abstract suspend fun deleteById(query: SupportSQLiteQuery) : Int
 
     @RawQuery
     protected abstract suspend fun findMultipleEntities(query: SupportSQLiteQuery): List<T>?


### PR DESCRIPTION
When trying to build with the new BaseRoomDao, it'll throw an error stating that RawQuery methods need to return a non-void type. This PR fixes that issue 

![image](https://user-images.githubusercontent.com/47658099/115254475-ad6af400-a12d-11eb-82e4-35b931b2d1ce.png)
