### PR TITLE
Group dependency versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,6 @@ dependencies {
     api "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version" //TODO: what does this thing do??
 
     //ViewModel
-    api "androidx.lifecycle:lifecycle-extensions:2.2.0" // TODO: This is deprecated (https://developer.android.com/jetpack/androidx/releases/lifecycle#2.2.0)
     api "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
 
     api "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,19 @@
 buildscript {
-    ext.kotlin_version = "1.4.32"
+    ext {
+        glide_version = "4.11.0"
+        kotlin_version = "1.4.32"
+        kotlinx_coroutines_version = "1.4.3"
+        lifecycle_version = "2.3.1"
+        material_dialogs_version = "3.3.0"
+        nav_version = "2.3.5"
+        okhttp_version = "4.9.1"
+        retrofit_version = "2.9.0"
+        room_version = "2.3.0"
+    }
 
     repositories {
         google()
-        maven { url 'https://plugins.gradle.org/m2/'}
+        maven { url 'https://plugins.gradle.org/m2/' }
         jcenter()
     }
     dependencies {
@@ -65,13 +75,13 @@ dependencies {
     api 'androidx.multidex:multidex:2.0.1'
 
     //Kotlin reflect
-    api "org.jetbrains.kotlin:kotlin-reflect:1.4.32" //TODO: what does this thing do??
+    api "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version" //TODO: what does this thing do??
 
     //ViewModel
-    api "androidx.lifecycle:lifecycle-extensions:2.2.0"
-    api "androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1"
+    api "androidx.lifecycle:lifecycle-extensions:2.2.0" // TODO: This is deprecated (https://developer.android.com/jetpack/androidx/releases/lifecycle#2.2.0)
+    api "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
 
-    api 'androidx.lifecycle:lifecycle-livedata-ktx:2.3.1'
+    api "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
 
     //AndroidX Support libraries
     api 'androidx.appcompat:appcompat:1.2.0'
@@ -80,20 +90,20 @@ dependencies {
     api "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
 
     //coroutines
-    api 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3'
-    api 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.3'
+    api "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinx_coroutines_version"
+    api "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinx_coroutines_version"
 
     // navigation components
-    api 'androidx.navigation:navigation-fragment-ktx:2.3.5'
-    api 'androidx.navigation:navigation-ui-ktx:2.3.5'
+    api "androidx.navigation:navigation-fragment-ktx:$nav_version"
+    api "androidx.navigation:navigation-ui-ktx:$nav_version"
 
     //networking
-    api 'com.squareup.retrofit2:converter-scalars:2.9.0'
-    api "com.squareup.retrofit2:retrofit:2.9.0"
-    api "com.squareup.retrofit2:converter-gson:2.9.0"
+    api "com.squareup.retrofit2:converter-scalars:$retrofit_version"
+    api "com.squareup.retrofit2:retrofit:$retrofit_version"
+    api "com.squareup.retrofit2:converter-gson:$retrofit_version"
 
-    api "com.squareup.okhttp3:okhttp:4.9.1"
-    api 'com.squareup.okhttp3:logging-interceptor:4.9.1'
+    api "com.squareup.okhttp3:okhttp:$okhttp_version"
+    api "com.squareup.okhttp3:logging-interceptor:$okhttp_version"
 
     // gson (https://github.com/google/gson)
     api 'com.google.code.gson:gson:2.8.6'
@@ -111,12 +121,12 @@ dependencies {
     api 'com.github.jkwiecien:EasyImage:3.0.3'
 
     //image loading/caching
-    api 'com.github.bumptech.glide:glide:4.11.0'
-    kapt 'com.github.bumptech.glide:compiler:4.11.0'
+    api "com.github.bumptech.glide:glide:$glide_version"
+    kapt "com.github.bumptech.glide:compiler:$glide_version"
 
     //dialogs
-    api 'com.afollestad.material-dialogs:core:3.3.0'
-    api 'com.afollestad.material-dialogs:datetime:3.3.0'
+    api "com.afollestad.material-dialogs:core:$material_dialogs_version"
+    api "com.afollestad.material-dialogs:datetime:$material_dialogs_version"
 
     // Time manipulation for Java 7
     api 'joda-time:joda-time:2.10.10'
@@ -131,11 +141,11 @@ dependencies {
     api 'com.github.razir.progressbutton:progressbutton:1.0.3'
 
     // Room Database
-    api "androidx.room:room-runtime:2.2.6"
-    kapt "androidx.room:room-compiler:2.2.6"
+    api "androidx.room:room-runtime:$room_version"
+    kapt "androidx.room:room-compiler:$room_version"
 
     // optional - Kotlin Extensions and Coroutines support for Room
-    api "androidx.room:room-ktx:2.2.6"
+    api "androidx.room:room-ktx:$room_version"
 }
 repositories {
     mavenCentral()


### PR DESCRIPTION
Added dependency version variables to group dependencies that are always in sync.
This will reduce the amount of PRs that Dependabot will make.

Removed deprecated `lifecycle-extensions` dependency