### PR TITLE
@ColumnInfo() for a BaseEntity breaks the RawQueries in BaseDao

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,12 @@ All notable changes to this project will be documented in this file.
 - `kotlin_version` added to `build.gradle` so our dependabot won't fail it's builds.
 - BaseEntity now expects an `id` param as an `Any` type.
 - Extension function `setupRecyclerView` is now more flexible.
+- Changed expected type of `id` from `Int` to `Any`
 
 ### Improvements
 
 - Added an `extraLogoutStep()` in `BaseNetworkingListeners` so it's easier to potentially keep some values in Hawk when logging out.
+- Added possibility to provide a custom `idColumnInfo` when needed in the `BaseDao`, default value will still be `id`
 
 ### Internal
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,33 @@ abstract class Dao: BaseRoomDao<Item>("item"){
 
 In case you omit the `open` keyword you'll get an error `error: Method annotated with @Transaction must not be private, final, or abstract.`
 
+### Custom 'id' column names
+
+When using `BaseEntity` and you wish to provide a different name for the `id` column, you can do so by using the `@ColumnInfo` on your Entity. Doing this, however, breaks the standard use of our `BaseDao` class. For it to work, just overridde the `idColumnInfo` in your Dao to tie it together.
+
+```kotlin
+override val idColumnInfo = DBConstants.COLUMN_ID_USER
+```
+
+I suggest to use a class to put all your Database constants in, i.e.:
+
+```kotlin
+object DBConstants {
+    const val DATABASE_NAME = "poemCollection.db"
+    const val USER_TABLE_NAME = "user"
+
+    const val COLUMN_ID_USER = "userId"
+}
+```
+
+Doing this will enable you to provide your table and column names in queries like so:
+
+```kotlin
+@Query("SELECT * FROM ${DBConstants.POEM_TABLE_NAME} WHERE ${DBConstants.COLUMN_ID_POEM} = :poemId")
+```
+
+Should you ever need to change those values, then you'd only have to do so in one location.
+
 ## <u>Contribution</u>
 
 All contributors are welcome. Take a look at [CONTRIBUTING.md](CONTRIBUTING.md) for more information.

--- a/src/main/java/be/appwise/core/data/base/BaseRoomDao.kt
+++ b/src/main/java/be/appwise/core/data/base/BaseRoomDao.kt
@@ -14,6 +14,8 @@ import androidx.sqlite.db.SupportSQLiteQuery
  */
 @Dao
 abstract class BaseRoomDao<T : BaseEntity>(private val tableName: String) {
+    open val idColumnInfo = "id"
+
     /**
      *  Inserts an entity object in the database.
      *  If the provided ID from the entity already exists, the object will be overwritten.
@@ -95,9 +97,9 @@ abstract class BaseRoomDao<T : BaseEntity>(private val tableName: String) {
      *  @return a list of the inserted ID's
      */
     suspend fun insertManyDeleteOthers(entities: List<T>) : List<Long> {
-        val ids = entities.joinToString { it -> "\'${it.id}\'" }
+        val ids = entities.joinToString { "\'${it.id}\'" }
 
-        val query = SimpleSQLiteQuery("DELETE FROM $tableName WHERE id NOT IN($ids);")
+        val query = SimpleSQLiteQuery("DELETE FROM $tableName WHERE $idColumnInfo NOT IN($ids);")
         deleteAllExceptIds(query)
 
         return insertMany(entities)
@@ -116,8 +118,8 @@ abstract class BaseRoomDao<T : BaseEntity>(private val tableName: String) {
      *
      *  @param id the id of the entity that needs to be deleted
      */
-    suspend fun deleteById(id: Int) {
-        val query = SimpleSQLiteQuery("DELETE FROM $tableName WHERE id = $id;")
+    suspend fun deleteById(id: Any) {
+        val query = SimpleSQLiteQuery("DELETE FROM $tableName WHERE $idColumnInfo = $id;")
         deleteById(query)
     }
 
@@ -136,10 +138,10 @@ abstract class BaseRoomDao<T : BaseEntity>(private val tableName: String) {
      * @param ids a list of ID's that needs to be searched for
      * @return a list of all entities that match the ID's from the given list
      */
-    suspend fun findEntitiesById(ids: List<Int>): List<T>? {
-        val formattedIds = ids.joinToString { it -> "\'${it}\'" }
+    suspend fun findEntitiesById(ids: List<Any>): List<T>? {
+        val formattedIds = ids.joinToString { "\'${it}\'" }
 
-        val query = SimpleSQLiteQuery("SELECT * FROM $tableName WHERE id IN ($formattedIds);")
+        val query = SimpleSQLiteQuery("SELECT * FROM $tableName WHERE $idColumnInfo IN ($formattedIds);")
         return findMultipleEntities(query)
     }
 
@@ -149,8 +151,8 @@ abstract class BaseRoomDao<T : BaseEntity>(private val tableName: String) {
      * @param id the ID of the object that needs to be searched for
      * @return the object if the ID matched
      */
-    suspend fun findEntityById(id: Int): T? {
-        val query = SimpleSQLiteQuery("SELECT * FROM $tableName WHERE id = $id")
+    suspend fun findEntityById(id: Any): T? {
+        val query = SimpleSQLiteQuery("SELECT * FROM $tableName WHERE $idColumnInfo = $id")
         return findSingleEntity(query)
     }
 
@@ -198,15 +200,15 @@ abstract class BaseRoomDao<T : BaseEntity>(private val tableName: String) {
         return findMultipleEntitiesLive(SimpleSQLiteQuery("SELECT * FROM $tableName;"))
     }
 
-    fun findEntitiesByIdLive(ids: List<Int>): LiveData<List<T>> {
+    fun findEntitiesByIdLive(ids: List<Any>): LiveData<List<T>> {
         val formattedIds = ids.joinToString { it -> "\'${it}\'" }
 
-        val query = SimpleSQLiteQuery("SELECT * FROM $tableName WHERE id IN ($formattedIds);")
+        val query = SimpleSQLiteQuery("SELECT * FROM $tableName WHERE $idColumnInfo IN ($formattedIds);")
         return findMultipleEntitiesLive(query)
     }
 
-    fun findEntityByIdLive(id: Int): LiveData<T> {
-        val query = SimpleSQLiteQuery("SELECT * FROM $tableName WHERE id = $id")
+    fun findEntityByIdLive(id: Any): LiveData<T> {
+        val query = SimpleSQLiteQuery("SELECT * FROM $tableName WHERE $idColumnInfo = $id")
         return findSingleEntityLive(query)
     }*/
 }


### PR DESCRIPTION
In some cases you wish to provide another name for the 'id' columns, be it for added relations between Entities or for something else. In those instances it will break the RawQueries in the BaseDao as they still expect `id` as the column name.

A new variable in BaseDao can be overridden to fix this issue. By default it will still be `id`, but it can easily be changed into something else. This PR will also changes the specified type of `id` from an `Int` to an `Any` to reflect the changes made for BaseEntity in #45 

Take a look at this example to see how this is needed to provide a M-M (many to many) relation between Poems and Categories.

```kotlin
data class PoemWithRelations(
    @Embedded var poem: Poem,
    @Relation(parentColumn = "id", entityColumn = "id", associateBy = Junction(PoemCategoryCrossRef::class))
    var categories: List<Category>
)
```

```kotlin
@Entity(primaryKeys = ["poemId", "categoryId"])
data class PoemCategoryCrossRef(
    val poemId: String,
    val categoryId: String
)
```

If both Poems and Categories have the `id` as a column name, building this would give this error.
`error: Cannot find the parent entity referencing column `id` in the junction`

By changing 
`@Relation(parentColumn = "id", entityColumn = "id", associateBy = Junction(PoemCategoryCrossRef::class))`
into
`@Relation(parentColumn = "poemId", entityColumn = "categoryId", associateBy = Junction(PoemCategoryCrossRef::class))`
everything works. But the BaseDao won't work. This PR will fix the issues in BaseDao.