### PR TITLE
Remove generic ViewModel from BaseVMFragment and BaseVMActivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Removed Realm from AndroidCore and replaced it with Room.
 - Updated `EasyImage` dependency which had breaking changes in some of our Extension functions.
 - Updated a lot of dependencies where a couple of them had some breaking changes, not major but still (functions turned to parameters).
+- Using `BaseBindingVMFragment`, `BaseVMFragment`, `BaseBindingVMActivity` or `BaseVMActivity` won't require you to add the ViewModel as a generic object
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
     mBinding.run {
-        lifeCycleOwner = viewLifeCycleOwner
         viewModel = mViewModel
     }
 }
@@ -141,7 +140,6 @@ override fun onViewCreated(view: View,s savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
 
     mBinding.run {
-        lifecycleOwner = viewLifecycleOwner
         viewModel = mViewModel.apply {
             // After the viewModel has been initialized you can use the functions and variables like normal
             fetchData()

--- a/README.md
+++ b/README.md
@@ -86,25 +86,25 @@ To reduce some boilerplate code whilst creating new Fragments or Activities you 
 - BaseVMFragment | BaseVMActivity
 - BaseBindingVMFragment |BaseBindingVMActivity
 
-Do mind, that by using `BaseBindingVM` equivalent you will automatically be using the other 2 as well. The hierarchy is as follows:
+Do mind, that by using the `BaseBindingVM` equivalent you will automatically be using the other 2 as well. The hierarchy is as follows:
 
 `BaseBindingVMFragment` -------extends-------> `BaseVMFragment` -------extends-------> `BaseFragment`
 
-### BaseVM...
+### <u>BaseVM...</u>
 
-By using `BaseVM...` you will need to override the value `mViewModel`. After that is set, the `DefaultExceptionHandler` will also be set automatically. You can override this as follows:
+By using `BaseVM...` you will need to override the value `mViewModel`. After that is set, the `DefaultExceptionHandler` will also be set automatically
 
 ```kotlin
 override val mViewModel: MainViewModel by viewModels()
 ```
 
-With `BaseVM...` you also have the option to add a custom `viewModelFactory` to it. For this to work you just need to override the function `getViewModelFactory()` like this.
+With `BaseVM...` you also have the option to add a custom `viewModelFactory` to it. For this to work you just need to override the function `getViewModelFactory()`
 
 ```kotlin
 override fun getViewModelFactory() = SplashViewModel.factory("someValue")
 ```
 
-You can then add the factory to the declaration of the `mViewModel` like so:
+You can then add the factory to the declaration of the `mViewModel`
 
 ```kotlin
 override val mViewModel: MainViewModel by viewModels() {
@@ -112,7 +112,44 @@ override val mViewModel: MainViewModel by viewModels() {
 }
 ```
 
-### BaseBindingVM...
+### <u>BaseBindingVM...</u>
+
+Everything that applies to `BaseVM...` applies to this class as well. A couple of things to add to this is that the Binding class is an expected Generic. You'll also have to override a function `getLayout()` to finish the basic setup for DataBinding
+
+```kotlin
+class MainFragment : BaseBindingVMFragment<FragmentMainBinding>() {
+    override fun getLayout() = R.layout.fragment_main
+
+}
+```
+
+If you have any variables in your layout that you wish to dataBind to it, you'll have to do that yourself in the `onCreate()` (for Activities) or `onViewCreated()` (for Fragments)
+
+```kotlin
+override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    mBinding.run {
+        lifeCycleOwner = viewLifeCycleOwner
+        viewModel = mViewModel
+    }
+}
+
+// OR
+
+override fun onViewCreated(view: View,s savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+
+    mBinding.run {
+        lifecycleOwner = viewLifecycleOwner
+        viewModel = mViewModel.apply {
+            // After the viewModel has been initialized you can use the functions and variables like normal
+            fetchData()
+        }
+    }
+}
+
+```
 
 ## <u>Contribution</u>
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,42 @@ abstract class Dao: BaseRoomDao<Item>("item"){
 
 In case you omit the `open` keyword you'll get an error `error: Method annotated with @Transaction must not be private, final, or abstract.`
 
+## <u>Base Activity Fragment</u>
+
+To reduce some boilerplate code whilst creating new Fragments or Activities you can use these BaseClasses
+
+- BaseFragment | BaseActivity
+- BaseVMFragment | BaseVMActivity
+- BaseBindingVMFragment |BaseBindingVMActivity
+
+Do mind, that by using `BaseBindingVM` equivalent you will automatically be using the other 2 as well. The hierarchy is as follows:
+
+`BaseBindingVMFragment` -------extends-------> `BaseVMFragment` -------extends-------> `BaseFragment`
+
+### BaseVM...
+
+By using `BaseVM...` you will need to override the value `mViewModel`. After that is set, the `DefaultExceptionHandler` will also be set automatically. You can override this as follows:
+
+```kotlin
+override val mViewModel: MainViewModel by viewModels()
+```
+
+With `BaseVM...` you also have the option to add a custom `viewModelFactory` to it. For this to work you just need to override the function `getViewModelFactory()` like this.
+
+```kotlin
+override fun getViewModelFactory() = SplashViewModel.factory("someValue")
+```
+
+You can then add the factory to the declaration of the `mViewModel` like so:
+
+```kotlin
+override val mViewModel: MainViewModel by viewModels() {
+    MainViewModel.factory("someValue")
+}
+```
+
+### BaseBindingVM...
+
 ## <u>Contribution</u>
 
 All contributors are welcome. Take a look at [CONTRIBUTING.md](CONTRIBUTING.md) for more information.

--- a/src/main/java/be/appwise/core/ui/base/BaseBindingVMActivity.kt
+++ b/src/main/java/be/appwise/core/ui/base/BaseBindingVMActivity.kt
@@ -14,6 +14,7 @@ abstract class BaseBindingVMActivity<B : ViewDataBinding> : BaseVMActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         mBinding = DataBindingUtil.setContentView(this, getLayout())
+        mBinding.lifecycleOwner = this
         super.onCreate(savedInstanceState)
     }
 }

--- a/src/main/java/be/appwise/core/ui/base/BaseBindingVMActivity.kt
+++ b/src/main/java/be/appwise/core/ui/base/BaseBindingVMActivity.kt
@@ -1,18 +1,19 @@
 package be.appwise.core.ui.base
 
+import android.os.Bundle
 import androidx.annotation.LayoutRes
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
 
-abstract class BaseBindingVMActivity<VM : BaseViewModel, B : ViewDataBinding> : BaseVMActivity<VM>() {
+abstract class BaseBindingVMActivity<B : ViewDataBinding> : BaseVMActivity() {
     protected lateinit var mBinding: B
         private set
 
     @LayoutRes
     protected abstract fun getLayout(): Int
 
-    override fun init() {
+    override fun onCreate(savedInstanceState: Bundle?) {
         mBinding = DataBindingUtil.setContentView(this, getLayout())
-        super.init()
+        super.onCreate(savedInstanceState)
     }
 }

--- a/src/main/java/be/appwise/core/ui/base/BaseBindingVMFragment.kt
+++ b/src/main/java/be/appwise/core/ui/base/BaseBindingVMFragment.kt
@@ -20,6 +20,7 @@ abstract class BaseBindingVMFragment<B : ViewDataBinding> : BaseVMFragment() {
      */
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         mBinding = DataBindingUtil.inflate(inflater, getLayout(), container, false)
+        mBinding.lifecycleOwner = viewLifecycleOwner
         return mBinding.root
     }
 }

--- a/src/main/java/be/appwise/core/ui/base/BaseBindingVMFragment.kt
+++ b/src/main/java/be/appwise/core/ui/base/BaseBindingVMFragment.kt
@@ -8,7 +8,7 @@ import androidx.annotation.LayoutRes
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
 
-abstract class BaseBindingVMFragment<VM : BaseViewModel, B : ViewDataBinding> : BaseVMFragment<VM>() {
+abstract class BaseBindingVMFragment<B : ViewDataBinding> : BaseVMFragment() {
     protected lateinit var mBinding: B
         private set
 

--- a/src/main/java/be/appwise/core/ui/base/BaseVMActivity.kt
+++ b/src/main/java/be/appwise/core/ui/base/BaseVMActivity.kt
@@ -3,26 +3,29 @@ package be.appwise.core.ui.base
 import android.os.Bundle
 import androidx.lifecycle.ViewModelProvider
 
-abstract class BaseVMActivity<VM : BaseViewModel> : BaseActivity() {
+abstract class BaseVMActivity : BaseActivity() {
     /**
-     * The viewModel that will be used for this Activity
+     * Reference to the viewModel that will be used for this Activity.
+     * When using this class, you should override [mViewModel] by using `by viewModels()`
+     *
+     * ```kotlin
+     *     override val mViewModel: MainViewModel by viewModels()
+     * ```
+     *
+     * you can even add a [ViewModelFactory] to it if needed.
+     *
+     *```kotlin
+     *     override val mViewModel: MainViewModel by viewModels() { getViewModelFactory() }
+     * ```
      */
-    protected lateinit var viewModel: VM
-        private set
-
-    protected abstract fun getViewModel(): Class<VM>
+    protected abstract val mViewModel: BaseViewModel
 
     protected open fun getViewModelFactory(): ViewModelProvider.NewInstanceFactory =
         ViewModelProvider.NewInstanceFactory()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        init()
-    }
 
-    protected open fun init() {
-        viewModel = ViewModelProvider(this, getViewModelFactory()).get(getViewModel()).apply {
-            setDefaultExceptionHandler(::onError)
-        }
+        mViewModel.setDefaultExceptionHandler(::onError)
     }
 }

--- a/src/main/java/be/appwise/core/ui/base/BaseVMFragment.kt
+++ b/src/main/java/be/appwise/core/ui/base/BaseVMFragment.kt
@@ -7,27 +7,30 @@ import be.appwise.core.R
 import be.appwise.core.extensions.fragment.snackBar
 import com.orhanobut.logger.Logger
 
-abstract class BaseVMFragment<VM : BaseViewModel> : Fragment() {
+abstract class BaseVMFragment : Fragment() {
     /**
-     * The viewModel that will be used for this Activity
+     * Reference to the viewModel that will be used for this Activity.
+     * When using this class, you should override [mViewModel] by using `by viewModels()`
+     *
+     * ```kotlin
+     *     override val mViewModel: MainViewModel by viewModels()
+     * ```
+     *
+     * you can even add a [ViewModelFactory] to it if needed.
+     *
+     *```kotlin
+     *     override val mViewModel: MainViewModel by viewModels() { getViewModelFactory() }
+     * ```
      */
-    protected lateinit var mViewModel: VM
-        private set
-
-    protected abstract fun getViewModel(): Class<VM>
+    protected abstract val mViewModel: BaseViewModel
 
     protected open fun getViewModelFactory(): ViewModelProvider.NewInstanceFactory =
         ViewModelProvider.NewInstanceFactory()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        init()
-    }
 
-    protected open fun init() {
-        mViewModel = ViewModelProvider(this, getViewModelFactory()).get(getViewModel()).apply {
-            setDefaultExceptionHandler(::onError)
-        }
+        mViewModel.setDefaultExceptionHandler(::onError)
     }
 
     open fun onError(throwable: Throwable) {


### PR DESCRIPTION
When using `BaseVMFragment` and `BaseVMActivity` before, you where required to add the ViewModel as a Generic type (`<>`).
```kotlin
class MainFragment : BaseVMFragment<MainViewModel>() {
      override fun getViewModel() = MainViewModel::class.java

}
``` 

This has now been removed and changes where made to `BaseBindingVMActivity` and `BaseBindingVMFragment` to reflect the removal.

The ReadMe changes will provide more information what this functionality specifically entails.