### PR TITLE
Bugfix/end of life jcenter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Master](https://github.com/appwise-labs/AndroidCore)
 
+### Bug Fixes
+
+- Removed 'JCenter' from the repositories list as that [service has been discontinued](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/).
+- Removed 'easyValidation' dependency as it was a deprecated library that was only available on JCenter.
 
 ## [1.0.0](https://github.com/appwise-labs/AndroidCore/releases/tag/1.0.0)
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,10 +14,9 @@ buildscript {
     repositories {
         google()
         maven { url 'https://plugins.gradle.org/m2/' }
-        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -25,7 +24,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         maven { url 'https://jitpack.io' }
     }
 }
@@ -106,9 +104,6 @@ dependencies {
 
     // gson (https://github.com/google/gson)
     api 'com.google.code.gson:gson:2.8.6'
-
-    //Validation
-    api "com.wajahatkarim3.easyvalidation:easyvalidation-core:1.0.1"
 
     // logger (https://github.com/orhanobut/logger)
     api 'com.orhanobut:logger:2.2.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
- Removed 'JCenter' from the repositories list as that [service has been discontinued](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/).
- Removed 'easyValidation' dependency as it was a deprecated library that was only available on JCenter.
