### PR TITLE
Bugfix/#74 run network calls in view model init block do not work with the error handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 - Added `getConverterFactories()` to the `BaseRestClient` so we can reorder ConverterFactories if needed.
+- Changed the default exception handler in the `BaseViewModel` so it will use a LiveData callback instead of a high order function.
+This makes sure that errors in a coroutine in the `init{}` block can be handled as well
 
 ### Improvements
 

--- a/core/src/main/java/be/appwise/core/ui/base/BaseVMActivity.kt
+++ b/core/src/main/java/be/appwise/core/ui/base/BaseVMActivity.kt
@@ -26,6 +26,9 @@ abstract class BaseVMActivity : BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        mViewModel.setDefaultExceptionHandler(::onError)
+        mViewModel.coroutineException.observe(this) {
+            if (it == null) return@observe
+            onError(it)
+        }
     }
 }

--- a/core/src/main/java/be/appwise/core/ui/base/BaseVMFragment.kt
+++ b/core/src/main/java/be/appwise/core/ui/base/BaseVMFragment.kt
@@ -26,6 +26,9 @@ abstract class BaseVMFragment : BaseFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        mViewModel.setDefaultExceptionHandler(::onError)
+        mViewModel.coroutineException.observe(viewLifecycleOwner) {
+            if (it == null) return@observe
+            onError(it)
+        }
     }
 }

--- a/core/src/main/java/be/appwise/core/ui/base/BaseVMFragment.kt
+++ b/core/src/main/java/be/appwise/core/ui/base/BaseVMFragment.kt
@@ -1,6 +1,7 @@
 package be.appwise.core.ui.base
 
 import android.os.Bundle
+import android.view.View
 import androidx.lifecycle.ViewModelProvider
 
 abstract class BaseVMFragment : BaseFragment() {
@@ -23,8 +24,8 @@ abstract class BaseVMFragment : BaseFragment() {
     protected open fun getViewModelFactory(): ViewModelProvider.NewInstanceFactory =
         ViewModelProvider.NewInstanceFactory()
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
 
         mViewModel.coroutineException.observe(viewLifecycleOwner) {
             if (it == null) return@observe

--- a/core/src/main/java/be/appwise/core/ui/base/BaseViewModel.kt
+++ b/core/src/main/java/be/appwise/core/ui/base/BaseViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import be.appwise.core.util.SingleLiveEvent
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
@@ -12,7 +13,7 @@ abstract class BaseViewModel : ViewModel() {
     @Suppress("MemberVisibilityCanBePrivate")
     var vmScope = viewModelScope
 
-    private val _coroutineException = MutableLiveData<Throwable?>(null)
+    private val _coroutineException = SingleLiveEvent<Throwable?>()
     val coroutineException: LiveData<Throwable?> = _coroutineException
 
     private val _loading = MutableLiveData<Boolean>().apply { value = false }


### PR DESCRIPTION
With this PR exceptions in a coroutine in the `init{}` block will be captured and handled by the `onError` of the fragment/activity as well.

This makes it possible to have certain network calls only run once when creating the viewModel and not every time the fragment gets opened again, or an orientation change happens.