### PR TITLE
#174 Changes to paging

### DIFF
--- a/data/paging/src/main/java/be/appwise/paging/base/BaseRemoteKeysDao.kt
+++ b/data/paging/src/main/java/be/appwise/paging/base/BaseRemoteKeysDao.kt
@@ -15,7 +15,7 @@ abstract class BaseRemoteKeysDao<T : BaseRemoteKeys>(private val tableName: Stri
     abstract suspend fun insertAll(remoteKey: List<T>)
 
     suspend fun remoteKeyId(id: Any): T? {
-        val query = SimpleSQLiteQuery("SELECT * FROM $tableName WHERE $idColumnInfo = $id")
+        val query = SimpleSQLiteQuery("SELECT * FROM $tableName WHERE $idColumnInfo = ?", arrayOf(id))
         return selectQuery(query)
     }
 

--- a/data/paging/src/main/java/be/appwise/paging/base/BaseRemoteMediator.kt
+++ b/data/paging/src/main/java/be/appwise/paging/base/BaseRemoteMediator.kt
@@ -21,7 +21,7 @@ abstract class BaseRemoteMediator<T: Any>: RemoteMediator<Int, T>() {
         }
 
         return try {
-            val isEndOfList = repository.loadPagedData(page, loadType)
+            val isEndOfList = repository.loadPagedData(page, loadType,state)
             MediatorResult.Success(endOfPaginationReached = isEndOfList)
         } catch (exception: Exception) {
             // This will handle any exceptions that happen when the data cannot be parsed by the "doCall" function

--- a/data/paging/src/main/java/be/appwise/paging/base/BaseRemoteRepository.kt
+++ b/data/paging/src/main/java/be/appwise/paging/base/BaseRemoteRepository.kt
@@ -1,9 +1,6 @@
 package be.appwise.paging.base
 
-import androidx.paging.ExperimentalPagingApi
-import androidx.paging.LoadType
-import androidx.paging.PagingConfig
-import androidx.paging.PagingData
+import androidx.paging.*
 import kotlinx.coroutines.flow.Flow
 
 interface BaseRemoteRepository<T : Any> {
@@ -15,7 +12,7 @@ interface BaseRemoteRepository<T : Any> {
 
     suspend fun getRemoteKeyById(item: T): BaseRemoteKeys?
 
-    suspend fun loadPagedData(page: Int, loadType: LoadType): Boolean
+    suspend fun loadPagedData(page: Int, loadType: LoadType,state: PagingState<Int, T>): Boolean
 
     /**
      * This functions expects to returns an [androidx.paging.Pager] object. This can be build by doing this


### PR DESCRIPTION
- Changed query for select remotekeyid so it will not give SQLExceptions when it has the type of String
-  Pass Pagingstate throught the BaseRemoteRepository loadPagedData function so we can get all the paging info (e.g. pagesize so we can pass it to network call if needed)