### PR TITLE
#176 make multiple pagingsources possible

### DIFF
--- a/data/paging/src/main/java/be/appwise/paging/base/BaseFilterRemoteMediator.kt
+++ b/data/paging/src/main/java/be/appwise/paging/base/BaseFilterRemoteMediator.kt
@@ -6,80 +6,93 @@ import androidx.paging.PagingState
 import androidx.paging.RemoteMediator
 
 @ExperimentalPagingApi
-    abstract class BaseFilterRemoteMediator<T : Any,QT : Any>(val query: QT) : RemoteMediator<Int, T>() {
-        abstract val repository: BaseFilterRemoteRepository<T, QT>
+abstract class BaseFilterRemoteMediator<T : Any, QT : Any>(
+    val query: QT,
+    val remoteFilterMediatorListener: RemoteFilterMediatorListener<T, QT>
+) : RemoteMediator<Int, T>() {
 
-        override suspend fun load(loadType: LoadType, state: PagingState<Int, T>): MediatorResult {
-            val page = when (val pageKeyData = getKeyPageData(loadType, state)) {
-                is MediatorResult.Success -> {
-                    return pageKeyData
-                }
-                else -> {
-                    pageKeyData as Int
-                }
+    override suspend fun load(loadType: LoadType, state: PagingState<Int, T>): MediatorResult {
+        val page = when (val pageKeyData = getKeyPageData(loadType, state)) {
+            is MediatorResult.Success -> {
+                return pageKeyData
             }
-
-            return try {
-                val isEndOfList = repository.loadPagedData(page, loadType, state, query)
-                MediatorResult.Success(endOfPaginationReached = isEndOfList)
-            } catch (exception: Exception) {
-                // This will handle any exceptions that happen when the data cannot be parsed by the "doCall" function
-                MediatorResult.Error(exception)
+            else -> {
+                pageKeyData as Int
             }
         }
 
-        /**
-         * this returns the page key or the final end of list success result
-         */
-        private suspend fun getKeyPageData(loadType: LoadType, state: PagingState<Int, T>): Any? {
-            return when (loadType) {
-                LoadType.REFRESH -> {
-                    val remoteKeys = getClosestRemoteKey(state)
-                    remoteKeys?.nextKey?.minus(1) ?: repository.defaultPageIndex
-                }
-                LoadType.APPEND -> {
-                    val remoteKeys = getLastRemoteKey(state)
-                    remoteKeys?.nextKey
-                        ?: return MediatorResult.Success(endOfPaginationReached = false)
-                    remoteKeys.nextKey
-                }
-                LoadType.PREPEND -> {
-                    val remoteKeys = getFirstRemoteKey(state)
-                    //end of list condition reached
-                    remoteKeys?.prevKey
-                        ?: return MediatorResult.Success(endOfPaginationReached = false)
-                    remoteKeys.prevKey
-                }
+        return try {
+            val isEndOfList = remoteFilterMediatorListener.loadPagedData(page, loadType, state, query)
+            MediatorResult.Success(endOfPaginationReached = isEndOfList)
+        } catch (exception: Exception) {
+            // This will handle any exceptions that happen when the data cannot be parsed by the "doCall" function
+            MediatorResult.Error(exception)
+        }
+    }
+
+    /**
+     * this returns the page key or the final end of list success result
+     */
+    private suspend fun getKeyPageData(loadType: LoadType, state: PagingState<Int, T>): Any? {
+        return when (loadType) {
+            LoadType.REFRESH -> {
+                val remoteKeys = getClosestRemoteKey(state)
+                remoteKeys?.nextKey?.minus(1) ?: remoteFilterMediatorListener.defaultPageIndex()
             }
-        }
-
-        /**
-         * get the first remote key inserted which had the data
-         */
-        private suspend fun getFirstRemoteKey(state: PagingState<Int, T>): BaseRemoteKeys? {
-            return state.pages
-                .firstOrNull { it.data.isNotEmpty() }
-                ?.data?.firstOrNull()
-                ?.let { feedback -> repository.getRemoteKeyById(feedback) }
-        }
-
-        /**
-         * get the last remote key inserted which had the data
-         */
-        private suspend fun getLastRemoteKey(state: PagingState<Int, T>): BaseRemoteKeys? {
-            return state.pages
-                .lastOrNull { it.data.isNotEmpty() }
-                ?.data?.lastOrNull()
-                ?.let { feedback -> repository.getRemoteKeyById(feedback) }
-        }
-
-        /**
-         * get the closest remote key inserted which had the data
-         */
-        private suspend fun getClosestRemoteKey(state: PagingState<Int, T>): BaseRemoteKeys? {
-            return state.anchorPosition?.let { position ->
-                state.closestItemToPosition(position)
-                    ?.let { feedback -> repository.getRemoteKeyById(feedback) }
+            LoadType.APPEND -> {
+                val remoteKeys = getLastRemoteKey(state)
+                remoteKeys?.nextKey
+                    ?: return MediatorResult.Success(endOfPaginationReached = false)
+                remoteKeys.nextKey
+            }
+            LoadType.PREPEND -> {
+                val remoteKeys = getFirstRemoteKey(state)
+                //end of list condition reached
+                remoteKeys?.prevKey
+                    ?: return MediatorResult.Success(endOfPaginationReached = false)
+                remoteKeys.prevKey
             }
         }
     }
+
+    /**
+     * get the first remote key inserted which had the data
+     */
+    private suspend fun getFirstRemoteKey(state: PagingState<Int, T>): BaseRemoteKeys? {
+        return state.pages
+            .firstOrNull { it.data.isNotEmpty() }
+            ?.data?.firstOrNull()
+            ?.let { feedback -> remoteFilterMediatorListener.getRemoteKeyById(feedback) }
+    }
+
+    /**
+     * get the last remote key inserted which had the data
+     */
+    private suspend fun getLastRemoteKey(state: PagingState<Int, T>): BaseRemoteKeys? {
+        return state.pages
+            .lastOrNull { it.data.isNotEmpty() }
+            ?.data?.lastOrNull()
+            ?.let { feedback -> remoteFilterMediatorListener.getRemoteKeyById(feedback) }
+    }
+
+    /**
+     * get the closest remote key inserted which had the data
+     */
+    private suspend fun getClosestRemoteKey(state: PagingState<Int, T>): BaseRemoteKeys? {
+        return state.anchorPosition?.let { position ->
+            state.closestItemToPosition(position)
+                ?.let { feedback -> remoteFilterMediatorListener.getRemoteKeyById(feedback) }
+        }
+    }
+
+    interface RemoteFilterMediatorListener<T : Any, QT : Any> {
+        fun getRemoteKeyById(t: T): BaseRemoteKeys?
+        fun defaultPageIndex(): Int
+        suspend fun loadPagedData(
+            page: Int,
+            loadType: LoadType,
+            state: PagingState<Int, T>,
+            query: QT
+        ): Boolean
+    }
+}

--- a/data/paging/src/main/java/be/appwise/paging/base/BaseFilterRemoteMediator.kt
+++ b/data/paging/src/main/java/be/appwise/paging/base/BaseFilterRemoteMediator.kt
@@ -86,7 +86,7 @@ abstract class BaseFilterRemoteMediator<T : Any, QT : Any>(
     }
 
     interface RemoteFilterMediatorListener<T : Any, QT : Any> {
-        fun getRemoteKeyById(t: T): BaseRemoteKeys?
+        suspend fun getRemoteKeyById(t: T): BaseRemoteKeys?
         fun defaultPageIndex(): Int
         suspend fun loadPagedData(
             page: Int,

--- a/data/paging/src/main/java/be/appwise/paging/base/BaseFilterRemoteRepository.kt
+++ b/data/paging/src/main/java/be/appwise/paging/base/BaseFilterRemoteRepository.kt
@@ -20,12 +20,12 @@ interface BaseFilterRemoteRepository<T : Any, QT : Any> {
 
     suspend fun getRemoteKeyById(item: T): BaseRemoteKeys?
 
-    suspend fun loadPagedData(
+    /*suspend fun loadPagedData(
         page: Int,
         loadType: LoadType,
         state: PagingState<Int, T>,
         query: QT
-    ): Boolean
+    ): Boolean*/
 
     /**
      * This functions expects to returns an [androidx.paging.Pager] object. This can be build by doing this

--- a/data/paging/src/main/java/be/appwise/paging/base/BaseRemoteMediator.kt
+++ b/data/paging/src/main/java/be/appwise/paging/base/BaseRemoteMediator.kt
@@ -82,7 +82,7 @@ abstract class BaseRemoteMediator<T : Any>(val remoteMediatorListener: RemoteMed
     }
 
     interface RemoteMediatorListener<T : Any> {
-        fun getRemoteKeyById(t: T) : BaseRemoteKeys?
+        suspend fun getRemoteKeyById(t: T) : BaseRemoteKeys?
         fun defaultPageIndex(): Int
         suspend fun loadPagedData(
             page: Int,

--- a/data/paging/src/main/java/be/appwise/paging/base/BaseRemoteRepository.kt
+++ b/data/paging/src/main/java/be/appwise/paging/base/BaseRemoteRepository.kt
@@ -6,13 +6,19 @@ import kotlinx.coroutines.flow.Flow
 interface BaseRemoteRepository<T : Any> {
     val defaultPageIndex: Int
 
-    fun getDefaultPageConfig(pageSize: Int = 15, initialLoadSize: Int = 30, enablePlaceholders: Boolean = false): PagingConfig {
-        return PagingConfig(pageSize = pageSize, initialLoadSize = initialLoadSize, enablePlaceholders = enablePlaceholders)
+    fun getDefaultPageConfig(
+        pageSize: Int = 15,
+        initialLoadSize: Int = 30,
+        enablePlaceholders: Boolean = false
+    ): PagingConfig {
+        return PagingConfig(
+            pageSize = pageSize,
+            initialLoadSize = initialLoadSize,
+            enablePlaceholders = enablePlaceholders
+        )
     }
 
     suspend fun getRemoteKeyById(item: T): BaseRemoteKeys?
-
-    suspend fun loadPagedData(page: Int, loadType: LoadType,state: PagingState<Int, T>): Boolean
 
     /**
      * This functions expects to returns an [androidx.paging.Pager] object. This can be build by doing this

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -47,7 +47,6 @@ dependencies {
     implementation project(path: ':measurements')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation project(path: ':data:paging')
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation project(path: ':measurements')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation project(path: ':data:paging')
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'


### PR DESCRIPTION
- Added interface as listener for Mediators so we can work with multiple pagesources and we don't need to pass repo to mediator
- Removed loadpageddata from baseremoterepository and move logic to listener in mediator